### PR TITLE
feat: add search on sort menu

### DIFF
--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -3,12 +3,14 @@ import { IconChevronDown, useIcons } from 'twenty-ui';
 import { OBJECT_SORT_DROPDOWN_ID } from '@/object-record/object-sort-dropdown/constants/ObjectSortDropdownId';
 import { useObjectSortDropdown } from '@/object-record/object-sort-dropdown/hooks/useObjectSortDropdown';
 import { ObjectSortDropdownScope } from '@/object-record/object-sort-dropdown/scopes/ObjectSortDropdownScope';
+import { StyledSearchInput } from '@/ui/field/input/components/TextInput';
 import { LightButton } from '@/ui/input/button/components/LightButton';
 import { Dropdown } from '@/ui/layout/dropdown/components/Dropdown';
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader';
 import { DropdownMenuItemsContainer } from '@/ui/layout/dropdown/components/DropdownMenuItemsContainer';
 import { DropdownMenuSeparator } from '@/ui/layout/dropdown/components/DropdownMenuSeparator';
 import { MenuItem } from '@/ui/navigation/menu-item/components/MenuItem';
+import { MenuItemEmpty } from '@/ui/navigation/menu-item/components/MenuItemEmpty';
 import { HotkeyScope } from '@/ui/utilities/hotkey/types/HotkeyScope';
 
 import { SORT_DIRECTIONS } from '../types/SortDirection';
@@ -30,7 +32,10 @@ export const ObjectSortDropdownButton = ({
     toggleSortDropdown,
     resetState,
     isSortSelected,
-    availableSortDefinitions,
+    searchInput,
+    handleChangeSearchInput,
+    isAvailableSortDefinitionsEmpty,
+    sortedAvailableSortDefinitions,
     handleAddSort,
   } = useObjectSortDropdown();
 
@@ -81,19 +86,31 @@ export const ObjectSortDropdownButton = ({
                   {selectedSortDirection === 'asc' ? 'Ascending' : 'Descending'}
                 </DropdownMenuHeader>
                 <DropdownMenuSeparator />
-                <DropdownMenuItemsContainer>
-                  {[...availableSortDefinitions]
-                    .sort((a, b) => a.label.localeCompare(b.label))
-                    .map((availableSortDefinition, index) => (
-                      <MenuItem
-                        testId={`select-sort-${index}`}
-                        key={index}
-                        onClick={() => handleAddSort(availableSortDefinition)}
-                        LeftIcon={getIcon(availableSortDefinition.iconName)}
-                        text={availableSortDefinition.label}
-                      />
-                    ))}
-                </DropdownMenuItemsContainer>
+                <StyledSearchInput
+                  placeholder="Search fields"
+                  value={searchInput}
+                  onChange={handleChangeSearchInput}
+                  autoFocus
+                />
+                {isAvailableSortDefinitionsEmpty ? (
+                  <DropdownMenuItemsContainer>
+                    <MenuItemEmpty text="No fields found" />
+                  </DropdownMenuItemsContainer>
+                ) : (
+                  <DropdownMenuItemsContainer>
+                    {sortedAvailableSortDefinitions
+                      .sort((a, b) => a.label.localeCompare(b.label))
+                      .map((availableSortDefinition, index) => (
+                        <MenuItem
+                          testId={`select-sort-${index}`}
+                          key={index}
+                          onClick={() => handleAddSort(availableSortDefinition)}
+                          LeftIcon={getIcon(availableSortDefinition.iconName)}
+                          text={availableSortDefinition.label}
+                        />
+                      ))}
+                  </DropdownMenuItemsContainer>
+                )}
               </>
             )}
           </>

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/components/ObjectSortDropdownButton.tsx
@@ -35,7 +35,7 @@ export const ObjectSortDropdownButton = ({
     searchInput,
     handleChangeSearchInput,
     isAvailableSortDefinitionsEmpty,
-    sortedAvailableSortDefinitions,
+    filteredAvailableSortDefinitions,
     handleAddSort,
   } = useObjectSortDropdown();
 
@@ -98,7 +98,7 @@ export const ObjectSortDropdownButton = ({
                   </DropdownMenuItemsContainer>
                 ) : (
                   <DropdownMenuItemsContainer>
-                    {sortedAvailableSortDefinitions
+                    {filteredAvailableSortDefinitions
                       .sort((a, b) => a.label.localeCompare(b.label))
                       .map((availableSortDefinition, index) => (
                         <MenuItem

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/hooks/useObjectSortDropdown.ts
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/hooks/useObjectSortDropdown.ts
@@ -66,13 +66,13 @@ export const useObjectSortDropdown = () => {
     });
   };
 
-  const sortedAvailableSortDefinitions = availableSortDefinitions.filter(
+  const filteredAvailableSortDefinitions = availableSortDefinitions.filter(
     (sortDefinition) =>
       sortDefinition.label.toLowerCase().includes(searchInput.toLowerCase()),
   );
 
   const isAvailableSortDefinitionsEmpty =
-    sortedAvailableSortDefinitions.length === 0;
+    filteredAvailableSortDefinitions.length === 0;
 
   const handleChangeSearchInput = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -91,7 +91,7 @@ export const useObjectSortDropdown = () => {
     availableSortDefinitions,
     handleAddSort,
     isAvailableSortDefinitionsEmpty,
-    sortedAvailableSortDefinitions,
+    filteredAvailableSortDefinitions,
     searchInput,
     handleChangeSearchInput,
   };

--- a/packages/twenty-front/src/modules/object-record/object-sort-dropdown/hooks/useObjectSortDropdown.ts
+++ b/packages/twenty-front/src/modules/object-record/object-sort-dropdown/hooks/useObjectSortDropdown.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { useSortDropdown } from '@/object-record/object-sort-dropdown/hooks/useSortDropdown';
@@ -14,6 +14,8 @@ import {
 
 // TODO: merge this with useSortDropdown
 export const useObjectSortDropdown = () => {
+  const [searchInput, setSearchInput] = useState('');
+
   const [isSortDirectionMenuUnfolded, setIsSortDirectionMenuUnfolded] =
     useRecoilState(isSortDirectionMenuUnfoldedState);
 
@@ -24,6 +26,7 @@ export const useObjectSortDropdown = () => {
   const resetState = useCallback(() => {
     setIsSortDirectionMenuUnfolded(false);
     setSelectedSortDirection('asc');
+    setSearchInput('');
   }, [setIsSortDirectionMenuUnfolded, setSelectedSortDirection]);
 
   const { toggleDropdown, closeDropdown } = useDropdown(
@@ -63,6 +66,20 @@ export const useObjectSortDropdown = () => {
     });
   };
 
+  const sortedAvailableSortDefinitions = availableSortDefinitions.filter(
+    (sortDefinition) =>
+      sortDefinition.label.toLowerCase().includes(searchInput.toLowerCase()),
+  );
+
+  const isAvailableSortDefinitionsEmpty =
+    sortedAvailableSortDefinitions.length === 0;
+
+  const handleChangeSearchInput = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setSearchInput(event.target.value);
+  };
+
   return {
     isSortDirectionMenuUnfolded,
     setIsSortDirectionMenuUnfolded,
@@ -73,5 +90,9 @@ export const useObjectSortDropdown = () => {
     isSortSelected,
     availableSortDefinitions,
     handleAddSort,
+    isAvailableSortDefinitionsEmpty,
+    sortedAvailableSortDefinitions,
+    searchInput,
+    handleChangeSearchInput,
   };
 };

--- a/packages/twenty-front/src/modules/ui/field/input/components/TextInput.tsx
+++ b/packages/twenty-front/src/modules/ui/field/input/components/TextInput.tsx
@@ -10,6 +10,11 @@ export const StyledTextInput = styled.input`
   width: 100%;
 `;
 
+export const StyledSearchInput = styled(StyledTextInput)`
+  border-bottom: 1px solid ${({ theme }) => theme.border.color.light};
+  padding: ${({ theme }) => theme.spacing(2)};
+`;
+
 type TextInputProps = {
   placeholder?: string;
   autoFocus?: boolean;

--- a/packages/twenty-front/src/modules/ui/navigation/menu-item/components/MenuItem.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/menu-item/components/MenuItem.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import { KeyboardEvent, MouseEvent, useState } from 'react';
 import { IconComponent } from 'twenty-ui';
 
 import { LightIconButtonGroup } from '@/ui/input/button/components/LightIconButtonGroup';
@@ -24,7 +24,9 @@ export type MenuItemProps = {
   isTooltipOpen?: boolean;
   className?: string;
   testId?: string;
-  onClick?: (event: MouseEvent<HTMLLIElement>) => void;
+  onClick?: (
+    event: MouseEvent<HTMLLIElement> | KeyboardEvent<HTMLLIElement>,
+  ) => void;
 };
 
 export const MenuItem = ({
@@ -38,9 +40,12 @@ export const MenuItem = ({
   testId,
   onClick,
 }: MenuItemProps) => {
+  const [isFocus, setFocus] = useState(false);
   const showIconButtons = Array.isArray(iconButtons) && iconButtons.length > 0;
 
-  const handleMenuItemClick = (event: MouseEvent<HTMLLIElement>) => {
+  const handleMenuItemClick = (
+    event: MouseEvent<HTMLLIElement> | KeyboardEvent<HTMLLIElement>,
+  ) => {
     if (!onClick) return;
     event.preventDefault();
     event.stopPropagation();
@@ -56,6 +61,15 @@ export const MenuItem = ({
       accent={accent}
       isMenuOpen={!!isTooltipOpen}
       isIconDisplayedOnHoverOnly={isIconDisplayedOnHoverOnly}
+      tabIndex={onClick ? 0 : -1}
+      onFocus={() => setFocus(true)}
+      onBlur={() => setFocus(false)}
+      onKeyDown={(event) => {
+        if (!onClick) return;
+        if (isFocus && event.key === 'Enter') {
+          handleMenuItemClick(event);
+        }
+      }}
     >
       <StyledMenuItemLeftContent>
         <MenuItemLeftContent LeftIcon={LeftIcon ?? undefined} text={text} />

--- a/packages/twenty-front/src/modules/ui/navigation/menu-item/components/MenuItemEmpty.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/menu-item/components/MenuItemEmpty.tsx
@@ -1,0 +1,9 @@
+import { StyledMenuItemEmpty } from '@/ui/navigation/menu-item/internals/components/StyledMenuItemBase';
+
+export type MenuItemEmptyProps = {
+  text: string;
+};
+
+export const MenuItemEmpty = ({ text }: MenuItemEmptyProps) => {
+  return <StyledMenuItemEmpty>{text}</StyledMenuItemEmpty>;
+};

--- a/packages/twenty-front/src/modules/ui/navigation/menu-item/internals/components/StyledMenuItemBase.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/menu-item/internals/components/StyledMenuItemBase.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import { FOCUS_BACKGROUND } from '@/ui/theme/constants/FocusBackground';
 import { HOVER_BACKGROUND } from '@/ui/theme/constants/HoverBackground';
 
 import { MenuItemAccent } from '../../types/MenuItemAccent';
@@ -33,6 +34,7 @@ export const StyledMenuItemBase = styled.li<MenuItemBaseProps>`
   padding: var(--vertical-padding) var(--horizontal-padding);
 
   ${HOVER_BACKGROUND};
+  ${FOCUS_BACKGROUND};
 
   ${({ theme, accent }) => {
     switch (accent) {
@@ -62,6 +64,12 @@ export const StyledMenuItemBase = styled.li<MenuItemBaseProps>`
   user-select: none;
 
   width: calc(100% - 2 * var(--horizontal-padding));
+`;
+
+export const StyledMenuItemEmpty = styled.div`
+  align-self: center;
+  padding: ${({ theme }) => theme.spacing(4)};
+  text-align: center;
 `;
 
 export const StyledMenuItemLabel = styled.div<{ hasLeftIcon: boolean }>`
@@ -113,7 +121,13 @@ export const StyledHoverableMenuItemBase = styled(StyledMenuItemBase)<{
     transition: opacity ${({ theme }) => theme.animation.duration.instant}s ease;
   }
 
-  &:hover {
+  &:focus-visible {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+
+  &:hover,
+  &:focus-visible {
     & .hoverable-buttons {
       opacity: 1;
       pointer-events: auto;

--- a/packages/twenty-front/src/modules/ui/theme/constants/FocusBackground.ts
+++ b/packages/twenty-front/src/modules/ui/theme/constants/FocusBackground.ts
@@ -1,0 +1,8 @@
+import { css } from '@emotion/react';
+
+export const FOCUS_BACKGROUND = (props: any) => css`
+  transition: background 0.1s ease;
+  &:focus-visible {
+    background: ${props.theme.background.transparent.light};
+  }
+`;


### PR DESCRIPTION
This new feature closes the related issue [#4368](https://github.com/twentyhq/twenty/issues/4368 ) on the Twenty repository.

### Issues met during development

After following the documentation on how to setup the project locally, I've been faced with a problem `Error during useFindManyRecords for "activities", QueryFailedError` on all pages. I tried to fix it but it was outside my knowledge of graphql. This results on not being able to see the list of peoples, companies and opportunities and not be able to see/show selected sort columns.

![CleanShot 2024-04-25 at 18 03 05@2x](https://github.com/armandsalle/twenty/assets/28579123/a1b41cee-3f4f-4430-982f-6960f859dabc)

### New feature

It makes possible to search for a specific column on the sort dropdown and add a small workaround to let people use the keyboards (tab & shift-tab) to select the column they want.
I've also added an empty state when the filter do not find anything.

### Screenshots

https://github.com/armandsalle/twenty/assets/28579123/9709cd81-aef1-4f94-8138-98727b76a97d

![CleanShot 2024-04-25 at 18 11 15@2x](https://github.com/armandsalle/twenty/assets/28579123/c51a3bdd-d3f9-4b63-8b97-aa2aeaf55d9d)
![CleanShot 2024-04-25 at 18 11 44@2x](https://github.com/armandsalle/twenty/assets/28579123/967bea49-f1ea-4379-82d8-0e8dd52aab6e)
![CleanShot 2024-04-25 at 18 12 01@2x](https://github.com/armandsalle/twenty/assets/28579123/5d4f19b2-4ee5-4161-bb5c-7284e2684a52)
